### PR TITLE
Small tidy-ups

### DIFF
--- a/avs/alexa.py
+++ b/avs/alexa.py
@@ -98,7 +98,7 @@ class Alexa(object):
         self.last_activity = datetime.datetime.utcnow()
         self._ping_time = None
 
-    def set_state_listner(self, listner):
+    def set_state_listener(self, listner):
         self.state_listener = listner
 
     def start(self):
@@ -478,7 +478,7 @@ def main():
 
     config = None if len(sys.argv) < 2 else sys.argv[1]
 
-    audio = Audio()
+    audio = Audio(frames_size=1600)
     alexa = Alexa(config)
 
     audio.link(alexa)

--- a/avs/auth.py
+++ b/avs/auth.py
@@ -104,8 +104,8 @@ def main(config, output):
     webserver = threading.Thread(target=login, args=(config, output))
     webserver.daemon = True
     webserver.start()
-    print("A web page should is opened. If not, go to http://127.0.0.1:3000 to start")
-    webbrowser.open('http://127.0.0.1:3000')
+    print("A web page should is opened. If not, go to http://localhost:3000 to start")
+    webbrowser.open('http://localhost:3000')
 
     while webserver.is_alive():
         try:

--- a/avs/config.py
+++ b/avs/config.py
@@ -24,11 +24,7 @@ def load(configfile=None):
                 }
 
             else:
-                return {
-                    "product_id": "ReSpeaker",
-                    "client_id": "amzn1.application-oa2-client.91b0cebd9074412cba1570a5dd03fc6e",
-                    "client_secret": "fbd7a0e72953c1dd9a920670cf7f4115f694cd47c32a1513dc12a804c7f804e2"
-                }
+                raise Exception('Could not find config file')
 
     with open(configfile, 'r') as f:
         config = json.load(f)


### PR DESCRIPTION
While getting familiar with the code, I found a number of small issues:

1. The frame size is set in `avs/main.py` for using hotwords, and in `avs/check.py`, but not in `avs/alexa.py`.
2. The examples for setting up valid callback URLs - for example https://github.com/alexa/alexa-avs-sample-app/wiki/Create-Security-Profile use localhost, not 127.0.0.1
3. There's a hardcoded ReSpeaker client ID & secret, which means if the user doesn't pass in `config.json`, they'll end up authorising your account by accident.